### PR TITLE
Remove Leave from optout and add location

### DIFF
--- a/CRM/Speakcivi/Page/Optout.php
+++ b/CRM/Speakcivi/Page/Optout.php
@@ -9,9 +9,10 @@ class CRM_Speakcivi_Page_Optout extends CRM_Speakcivi_Page_Post {
     $this->setIsOptOut($this->contactId, 1);
 
     $groupId = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'group_id');
+    $location = '';
     if ($this->isGroupContactAdded($this->contactId, $groupId)) {
-      CRM_Speakcivi_Logic_Activity::leave($this->contactId, 'confirmation_link', $this->campaignId);
       $this->setGroupContactRemoved($this->contactId, $groupId);
+      $location = 'removed from Members after optout link';
     }
 
     if ($this->campaignId) {
@@ -23,7 +24,7 @@ class CRM_Speakcivi_Page_Optout extends CRM_Speakcivi_Page_Post {
     }
 
     $aids = $this->findActivitiesIds($this->activityId, $this->campaignId, $this->contactId);
-    $this->setActivitiesStatuses($this->activityId, $aids, 'optout');
+    $this->setActivitiesStatuses($this->activityId, $aids, 'optout', $location);
 
     $country = $this->getCountry($this->campaignId);
     $url = "{$country}/post_optout";

--- a/CRM/Speakcivi/Page/Post.php
+++ b/CRM/Speakcivi/Page/Post.php
@@ -56,10 +56,11 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
    *
    * @param int $activityId
    * @param string $status
+   * @param string $location
    *
    * @throws CiviCRM_API3_Exception
    */
-  public function setActivityStatus($activityId, $status = 'optout') {
+  public function setActivityStatus($activityId, $status = 'optout', $location = '') {
     if ($activityId > 0) {
       $scheduledId = CRM_Speakcivi_Logic_Activity::getStatusId('Scheduled');
       $params = array(
@@ -71,6 +72,7 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
       if ($result['count'] == 1) {
         $newStatusId = CRM_Speakcivi_Logic_Activity::getStatusId($status);
         $params['status_id'] = $newStatusId;
+        $params['location'] = $location;
         civicrm_api3('Activity', 'create', $params);
       }
     }
@@ -83,14 +85,15 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
    * @param integer $activityId
    * @param array $aids array of activities ids
    * @param string $status
+   * @param string $location
    */
-  public function setActivitiesStatuses($activityId, $aids, $status = 'Completed') {
+  public function setActivitiesStatuses($activityId, $aids, $status = 'Completed', $location = '') {
     if (is_array($aids) && count($aids) > 0) {
       foreach ($aids as $aid) {
-        $this->setActivityStatus($aid, $status);
+        $this->setActivityStatus($aid, $status, $location);
       }
     } else {
-      $this->setActivityStatus($activityId, $status);
+      $this->setActivityStatus($activityId, $status, $location);
     }
   }
 


### PR DESCRIPTION
Each activity Petition signature has `location = removed from Members after optout link` If contact was removed from group (It shouldn't be in this group). Location is only using as note.