### PR TITLE
New consent-only endpoint

### DIFF
--- a/CRM/Speakcivi/Page/Confirm.php
+++ b/CRM/Speakcivi/Page/Confirm.php
@@ -12,27 +12,8 @@ class CRM_Speakcivi_Page_Confirm extends CRM_Speakcivi_Page_Post {
     $this->setActivityStatusIds();
     $this->setValues();
 
-    $country = $this->getCountry($this->campaignId);
-    $consentIds = $this->getConsentIds($this->campaignId);
-    // fixme which consent should be set at contact level?
-    // fixme assumption: first
-    if ($consentIds) {
-      $consentVersion = explode('-', $consentIds[0])[0];
-    }
-    else {
-      $consentVersion = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'gdpr_privacy_pack_version');
-    }
-    $contactParams = array(
-      'is_opt_out' => 0,
-      'do_not_email' => 0,
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_date') => date('Y-m-d'),
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_version') => $consentVersion,
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_language') => strtoupper($country),
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_utm_source') => $this->utmSource,
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_utm_medium') => $this->utmMedium,
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_utm_campaign') => $this->utmCampaign,
-      CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_consent_campaign_id') => $this->campaignId,
-    );
+    $campaign = new CRM_Speakcivi_Logic_Campaign($this->campaignId);
+    $contactParams = $this->getContactConsentParams($campaign);
 
     $groupId = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'group_id');
     if (!$this->isGroupContactAdded($this->contactId, $groupId)) {
@@ -53,11 +34,8 @@ class CRM_Speakcivi_Page_Confirm extends CRM_Speakcivi_Page_Post {
       CRM_Speakcivi_Logic_Contact::unholdEmail($email['email_id']);
     }
 
-    $redirect = '';
-    if ($this->campaignId) {
-      $campaign = new CRM_Speakcivi_Logic_Campaign($this->campaignId);
+    if ($campaign) {
       $locale = $campaign->getLanguage();
-      $redirect = $campaign->getRedirectConfirm();
       $language = substr($locale, 0, 2);
       $rlg = $this->setLanguageGroup($this->contactId, $language);
       $this->setLanguageTag($this->contactId, $language);
@@ -67,25 +45,7 @@ class CRM_Speakcivi_Page_Confirm extends CRM_Speakcivi_Page_Post {
     }
 
     CRM_Speakcivi_Logic_Contact::set($this->contactId, $contactParams);
-
-    $consent = new CRM_Speakcivi_Logic_Consent();
-    $consent->createDate = date('YmdHis');
-    $consent->utmSource = $this->utmSource;
-    $consent->utmMedium = $this->utmMedium;
-    $consent->utmCampaign = $this->utmCampaign;
-    if ($consentIds) {
-      foreach ($consentIds as $id) {
-        list($consentVersion, $language) = explode('-', $id);
-        $consent->version = $consentVersion;
-        $consent->language = $language;
-        CRM_Speakcivi_Logic_Activity::dpa($consent, $this->contactId, $this->campaignId, 'Completed');
-      }
-    }
-    else {
-      $consent->version = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'gdpr_privacy_pack_version');
-      $consent->language = $country;
-      CRM_Speakcivi_Logic_Activity::dpa($consent, $this->contactId, $this->campaignId, 'Completed');
-    }
+    $this->createConsentActivities($campaign);
 
     $activityStatus = 'optin'; // default status: Completed new member
     $aids = $this->findActivitiesIds($this->activityId, $this->campaignId, $this->contactId);
@@ -94,13 +54,7 @@ class CRM_Speakcivi_Page_Confirm extends CRM_Speakcivi_Page_Post {
     $speakcivi = new CRM_Speakcivi_Page_Speakcivi();
     $speakcivi->sendConfirm($email['email'], $this->contactId, $this->activityId, $this->campaignId, FALSE, FALSE, 'new_member');
 
-    $context = array(
-      'drupal_language' => $country,
-      'contact_id' => $this->contactId,
-      'contact_checksum' => CRM_Contact_BAO_Contact_Utils::generateChecksum($this->contactId),
-    );
-    $url = $this->determineRedirectUrl('post_confirm', $country, $redirect, $context);
-    CRM_Utils_System::redirect($url);
+    $this->redirect($campaign, 'post_confirm');
   }
 
 }

--- a/CRM/Speakcivi/Page/Consent.php
+++ b/CRM/Speakcivi/Page/Consent.php
@@ -9,6 +9,11 @@ require_once 'CRM/Core/Page.php';
  */
 class CRM_Speakcivi_Page_Consent extends CRM_Speakcivi_Page_Post {
 
+  /**
+   * @return null|void
+   * @throws \CiviCRM_API3_Exception
+   * @throws \Exception
+   */
   public function run() {
     $this->setValues();
     $campaign = new CRM_Speakcivi_Logic_Campaign($this->campaignId);

--- a/CRM/Speakcivi/Page/Consent.php
+++ b/CRM/Speakcivi/Page/Consent.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once 'CRM/Core/Page.php';
+
+/**
+ * Endpoint to add consent activity to a contact.
+ * The consent id is determined from the campaign, which is given as a request parameter.
+ * The user is then redirected to a thank you page, also determined from the campaign.
+ */
+class CRM_Speakcivi_Page_Consent extends CRM_Speakcivi_Page_Post {
+
+  public function run() {
+    $this->setValues();
+    $campaign = new CRM_Speakcivi_Logic_Campaign($this->campaignId);
+
+    $contactParams = $this->getContactConsentParams($campaign);
+    CRM_Speakcivi_Logic_Contact::set($this->contactId, $contactParams);
+
+    $this->createConsentActivities($campaign);
+
+    $this->redirect($campaign);
+  }
+
+}

--- a/CRM/Speakcivi/Page/Post.php
+++ b/CRM/Speakcivi/Page/Post.php
@@ -68,11 +68,9 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
 
 
   /**
-   * Get country prefix based on campaign id.
-   *
    * @param int $campaignId
-   *
-   * @return string
+   * @return string the language code (not locale) of the campaign
+   * TODO: rename to getLanguage
    */
   public function getCountry($campaignId) {
     $country = '';
@@ -104,6 +102,63 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
     }
 
     return [];
+  }
+
+  /**
+   * Based on given campaign and request parameters, 
+   * determine the consent-related values to apply to the contact.
+   */
+  public function getContactConsentParams($campaign) {
+    $locale = $campaign->getLanguage();
+    $language = substr($locale, 0, 2);
+    $consentIds = explode(',', $campaign->getConsentIds());
+    if ($consentIds) {
+      list($consentVersion, $language) = explode('-', $consentIds[0]);
+    }
+    else {
+      $consentVersion = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'gdpr_privacy_pack_version');
+    }
+
+    $contactParams = array(
+      'is_opt_out' => 0,
+      'do_not_email' => 0,
+      $this->fieldName('consent_date') => date('Y-m-d'),
+      $this->fieldName('consent_version') => $consentVersion,
+      $this->fieldName('consent_language') => strtoupper($language),
+      $this->fieldName('consent_utm_source') => $this->utmSource,
+      $this->fieldName('consent_utm_medium') => $this->utmMedium,
+      $this->fieldName('consent_utm_campaign') => $this->utmCampaign,
+      $this->fieldName('consent_campaign_id') => $this->campaignId,
+    );
+
+    return $contactParams;
+  }
+
+  /**
+   * Based on give campaign and request parameters,
+   * create an activity for all the consents implied by the request
+   */
+  public function createConsentActivities($campaign) {
+    $consent = new CRM_Speakcivi_Logic_Consent();
+    $consent->createDate = date('YmdHis');
+    $consent->utmSource = $this->utmSource;
+    $consent->utmMedium = $this->utmMedium;
+    $consent->utmCampaign = $this->utmCampaign;
+
+    $consentIds = explode(',', $campaign->getConsentIds());
+    if ($consentIds) {
+      foreach ($consentIds as $id) {
+        list($consentVersion, $language) = explode('-', $id);
+        $consent->version = $consentVersion;
+        $consent->language = $language;
+        CRM_Speakcivi_Logic_Activity::dpa($consent, $this->contactId, $this->campaignId, 'Completed');
+      }
+    }
+    else {
+      $consent->version = CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'gdpr_privacy_pack_version');
+      $consent->language = substr($campaign->getLanguage(), 0, 2);
+      CRM_Speakcivi_Logic_Activity::dpa($consent, $this->contactId, $this->campaignId, 'Completed');
+    }
   }
 
   /**
@@ -520,5 +575,21 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
       return "/{$lang}/{$page}";
     }
     return "/{$page}";
+  }
+
+  public function redirect($campaign, $defaultPage = 'thank-you-for-your-confirmation') {
+    $language = substr($campaign->getLanguage(), 0, 2);
+    $redirect = $campaign->getRedirectConfirm();
+    $context = array(
+      'drupal_language' => $language,
+      'contact_id' => $this->contactId,
+      'contact_checksum' => CRM_Contact_BAO_Contact_Utils::generateChecksum($this->contactId),
+    );
+    $url = $this->determineRedirectUrl($defaultPage, $language, $redirect, $context);
+    CRM_Utils_System::redirect($url);
+  }
+
+  public function fieldName($name) {
+    return CRM_Core_BAO_Setting::getItem('Speakcivi API Preferences', 'field_' . $name);
   }
 }

--- a/CRM/Speakcivi/Page/Post.php
+++ b/CRM/Speakcivi/Page/Post.php
@@ -105,10 +105,14 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
   }
 
   /**
-   * Based on given campaign and request parameters, 
+   * Based on given campaign and request parameters,
    * determine the consent-related values to apply to the contact.
+   *
+   * @param \CRM_Speakcivi_Logic_Campaign $campaign
+   *
+   * @return array
    */
-  public function getContactConsentParams($campaign) {
+  public function getContactConsentParams(CRM_Speakcivi_Logic_Campaign $campaign) {
     $locale = $campaign->getLanguage();
     $language = substr($locale, 0, 2);
     $consentIds = explode(',', $campaign->getConsentIds());
@@ -137,8 +141,12 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
   /**
    * Based on give campaign and request parameters,
    * create an activity for all the consents implied by the request
+   *
+   * @param \CRM_Speakcivi_Logic_Campaign $campaign
+   *
+   * @throws \CiviCRM_API3_Exception
    */
-  public function createConsentActivities($campaign) {
+  public function createConsentActivities(CRM_Speakcivi_Logic_Campaign $campaign) {
     $consent = new CRM_Speakcivi_Logic_Consent();
     $consent->createDate = date('YmdHis');
     $consent->utmSource = $this->utmSource;
@@ -550,6 +558,13 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
   /**
    * Build the post-confirmation URL
    * TODO: use a proper token mecanism
+   *
+   * @param $page
+   * @param $country
+   * @param $redirect
+   * @param null $context
+   *
+   * @return mixed|string
    */
   public function determineRedirectUrl($page, $country, $redirect, $context = NULL) {
     if ($context != NULL) {
@@ -577,7 +592,11 @@ class CRM_Speakcivi_Page_Post extends CRM_Core_Page {
     return "/{$page}";
   }
 
-  public function redirect($campaign, $defaultPage = 'thank-you-for-your-confirmation') {
+  /**
+   * @param \CRM_Speakcivi_Logic_Campaign $campaign
+   * @param string $defaultPage
+   */
+  public function redirect(CRM_Speakcivi_Logic_Campaign $campaign, $defaultPage = 'thank-you-for-your-confirmation') {
     $language = substr($campaign->getLanguage(), 0, 2);
     $redirect = $campaign->getRedirectConfirm();
     $context = array(

--- a/xml/Menu/speakcivi.xml
+++ b/xml/Menu/speakcivi.xml
@@ -35,6 +35,13 @@
     <is_public>true</is_public>
   </item>
   <item>
+    <path>civicrm/consent/confirm</path>
+    <page_callback>CRM_Speakcivi_Page_Consent</page_callback>
+    <title>Thank you</title>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+  </item>
+  <item>
     <path>civicrm/speakout/confirm</path>
     <page_callback>CRM_Speakcivi_Page_Confirm</page_callback>
     <title>Your signature is confirmed</title>


### PR DESCRIPTION
Adds a CiviCRM page that add consent activities to a contact based on request parameters, and redirects to a content page. The consent parameters and redirect page are determined from the campaign id given in request parameters.

In a nutshell, this is the confirmation page without the post-signature behaviour.