### PR TITLE
Add a custom token for member city

### DIFF
--- a/CRM/Speakcivi/Tools/Dictionary.php
+++ b/CRM/Speakcivi/Tools/Dictionary.php
@@ -453,4 +453,40 @@ class CRM_Speakcivi_Tools_Dictionary {
     }
     return $content;
   }
+
+  public static function fallbackCityValues() {
+    return array(
+        "fr_FR" => "votre ville",
+        "de_DE" => "deine Stadt",
+        "en_GB" => "your city",
+        "en_US" => "your city",
+        "pl_PL" => "Twoje miasto",
+    );
+  }
+
+    /**
+    * Cached look up for the language for a mailing using a job id.
+    *
+    * Each job is linked to one mailing, so we can cache the language of the
+    * mailing using the job as a key.
+    *
+    * @param int $job - id of a MailingJob
+    */
+    function findMailingLanguage($job) {
+        $cache_key = "speakcivi:mailinglanguage:$job";
+        $language = Civi::cache()->get($cache_key);
+        if ($language) { 
+            return $language;
+        }
+        $dao = CRM_Core_DAO::executeQuery("
+    SELECT m.language 
+    FROM civicrm_mailing_job j 
+    JOIN civicrm_mailing m ON m.id=j.mailing_id 
+    WHERE j.id=$job
+    "
+        );
+        $language = $dao->fetchValue();
+        Civi::cache()->set($cache_key, $language);
+        return $language;
+    }
 }

--- a/speakcivi.php
+++ b/speakcivi.php
@@ -139,14 +139,21 @@ function speakcivi_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = a
 }
 
 function findMailingLanguage($job) {
+    $cache_key = "speakcivi:mailinglanguage:$job";
+    $language = Civi::cache()->get($cache_key);
+    if ($language) { 
+        return $language;
+    }
     $dao = CRM_Core_DAO::executeQuery("
 SELECT m.language 
 FROM civicrm_mailing_job j 
 JOIN civicrm_mailing m ON m.id=j.mailing_id 
 WHERE j.id=$job
-",
+"
     );
-    return $dao->fetchValue();
+    $language = $dao->fetchValue();
+    Civi::cache()->set($cache_key, $language);
+    return $language;
 }
 
 

--- a/speakcivi.php
+++ b/speakcivi.php
@@ -137,7 +137,7 @@ function speakcivi_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = a
     $values[$cid]['speakcivi.confirmation_hash'] = sha1(CIVICRM_SITE_KEY . $cid);
 
     if ($wantsCity && empty($values[$cid]['city'])) {
-        $values[$cid]['city'] = $cityDefaultValues[$language];
+        $values[$cid]['city'] = CRM_Utils_Array::value($language, $cityDefaultValues, 'your city');
     }
   }
 


### PR DESCRIPTION
Adds a custom token for member city - with fallbacks in each language.

Questions:

This code uses the member's preferred language - which @rthouvenin said wasn't so great. There's no way to get at the mailing here. 

ToDo:

- [x] Check for drift between language groups and preferred_language
- [x] Add all languages organizers / campaigners want
- [x] Get sign off that the translations and limitations are OK
