### PR TITLE
Stop trying to find a language when it is not needed

### DIFF
--- a/speakcivi.php
+++ b/speakcivi.php
@@ -129,7 +129,7 @@ function speakcivi_civicrm_tokens(&$tokens) {
  * @param null $context  // no idea
  */
 function speakcivi_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(), $context = null) {
-  $wantsCity = array_key_exists('city', $tokens['contact']) and $job;
+  $wantsCity = array_key_exists('city', $tokens['contact']) && $job;
   if ($wantsCity) {
     $language = CRM_Speakcivi_Tools_Dictionary::findMailingLanguage($job);
     $cityDefaultValues = CRM_Speakcivi_Tools_Dictionary::fallbackCityValues();

--- a/speakcivi.php
+++ b/speakcivi.php
@@ -129,9 +129,11 @@ function speakcivi_civicrm_tokens(&$tokens) {
  * @param null $context  // no idea
  */
 function speakcivi_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(), $context = null) {
-  $language = CRM_Speakcivi_Tools_Dictionary::findMailingLanguage($job);
-  $cityDefaultValues = CRM_Speakcivi_Tools_Dictionary::fallbackCityValues();
-  $wantsCity = array_key_exists('city', $tokens['contact']);
+  $wantsCity = array_key_exists('city', $tokens['contact']) and $job;
+  if ($wantsCity) {
+    $language = CRM_Speakcivi_Tools_Dictionary::findMailingLanguage($job);
+    $cityDefaultValues = CRM_Speakcivi_Tools_Dictionary::fallbackCityValues();
+  }
 
   foreach ($cids as $cid) {
     $values[$cid]['speakcivi.confirmation_hash'] = sha1(CIVICRM_SITE_KEY . $cid);


### PR DESCRIPTION
Hotfix for a live bug - trying to load the languages for cities when it's not a mailing and job is not defined. 