### PR TITLE
WIP: Fetch Speakout campaign information directly

### DIFF
--- a/CRM/Speakcivi/Logic/Cache/SpeakoutCampaign.php
+++ b/CRM/Speakcivi/Logic/Cache/SpeakoutCampaign.php
@@ -1,0 +1,26 @@
+<?php
+
+class CRM_Speakcivi_Logic_Cache_SpeakoutCampaign extends CRM_Speakcivi_Logic_Cache
+{
+
+    const CACHE_PREFIX = '-speakout-';
+
+    public static function getCampaign($speakoutDomain, $speakoutCampaignId)
+    {
+        if ($speakout_campaign = self::get(
+            self::CACHE_PREFIX,
+            "$speakoutDomain:$speakoutCampaignId"
+        )) {
+            return $speakout_campaign;
+        }
+
+        $url = "https://$speakoutDomain/api/v1/campaigns/$speakoutCampaignId";
+        $user = CIVICRM_SPEAKOUT_USERS[$speakoutDomain];
+        $auth = $user['email'] . ':' . $user['password'];
+        $speakout_campaign = (array)json_decode(fetchSpeakoutContent($url, $auth));
+
+        self::set(self::CACHE_PREFIX, "$speakoutDomain:$speakoutCampaignId", $speakout_campaign, 300); # TODO: Set in configuration
+
+        return $speakout_campaign;
+    }
+}

--- a/CRM/Speakcivi/Logic/Cache/SpeakoutCampaign.php
+++ b/CRM/Speakcivi/Logic/Cache/SpeakoutCampaign.php
@@ -11,7 +11,7 @@ class CRM_Speakcivi_Logic_Cache_SpeakoutCampaign extends CRM_Speakcivi_Logic_Cac
             self::CACHE_PREFIX,
             "$speakoutDomain:$speakoutCampaignId"
         )) {
-            return $speakout_campaign;
+            return $speakout_campaign[self::CACHE_PREFIX];
         }
 
         $url = "https://$speakoutDomain/api/v1/campaigns/$speakoutCampaignId";

--- a/CRM/Speakcivi/Logic/Campaign.php
+++ b/CRM/Speakcivi/Logic/Campaign.php
@@ -498,10 +498,10 @@ class CRM_Speakcivi_Logic_Campaign {
     curl_close($ch);
     if ($code == 200) {
       return $data;
-    } elseif ($code = 404) {
+    } 
+    if ($code == 404) {
       throw new CRM_Speakcivi_Exception('Speakout campaign doesnt exist: ' . $url, 1);
-    } else {
-      throw new CRM_Speakcivi_Exception('Speakout campaign is unavailable' . $url, 2);
-    }
+    } 
+    throw new CRM_Speakcivi_Exception('Speakout campaign is unavailable: ' . $url, 2);
   }
 }

--- a/CRM/Speakcivi/Logic/Campaign.php
+++ b/CRM/Speakcivi/Logic/Campaign.php
@@ -486,22 +486,27 @@ class CRM_Speakcivi_Logic_Campaign {
    * @throws \CRM_Speakcivi_Exception
    */
   public function getContent($url, $authString = NULL) {
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    if ($authString != NULL) {
-      curl_setopt($ch, CURLOPT_USERPWD, $authString);
-    }
-    $data = curl_exec($ch);
-    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-    if ($code == 200) {
-      return $data;
-    } 
-    if ($code == 404) {
-      throw new CRM_Speakcivi_Exception('Speakout campaign doesnt exist: ' . $url, 1);
-    } 
-    throw new CRM_Speakcivi_Exception('Speakout campaign is unavailable: ' . $url, 2);
+    return fetchSpeakoutContent($url, $authstring = NULL);
+
   }
+}
+
+function fetchSpeakoutContent($url, $authString = NULL) {
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, $url);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+  if ($authString != NULL) {
+    curl_setopt($ch, CURLOPT_USERPWD, $authString);
+  }
+  $data = curl_exec($ch);
+  $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+  curl_close($ch);
+  if ($code == 200) {
+    return $data;
+  } 
+  if ($code == 404) {
+    throw new CRM_Speakcivi_Exception('Speakout campaign doesnt exist: ' . $url, 1);
+  } 
+  throw new CRM_Speakcivi_Exception('Speakout campaign is unavailable: ' . $url, 2);
 }

--- a/CRM/Speakcivi/Page/Speakcivi.php
+++ b/CRM/Speakcivi/Page/Speakcivi.php
@@ -218,7 +218,8 @@ class CRM_Speakcivi_Page_Speakcivi extends CRM_Core_Page {
             civicrm_api3('Gidipirus', 'set_consent_status', $params);
           }
         }
-        $sendResult = $this->sendEmail($this->isAnonymous, $h->emails[0]->email, $contact['id'], $activity['id'], $this->campaignId, $this->confirmationBlock, $noMember);
+        $action_technical_type = $param->action_technical_type;
+        $sendResult = $this->sendEmail($this->isAnonymous, $h->emails[0]->email, $contact['id'], $activity['id'], $this->campaignId, $this->confirmationBlock, $noMember, '', $action_technical_type);
       }
       else {
         $rlg = 0;
@@ -276,7 +277,8 @@ class CRM_Speakcivi_Page_Speakcivi extends CRM_Core_Page {
 
         if ($this->consentStatus == CRM_Speakcivi_Logic_Consent::STATUS_ACCEPTED) {
           $share_utm_source = 'post-action';
-          $sendResult = $this->sendEmail($this->isAnonymous, $h->emails[0]->email, $contact['id'], $activity['id'], $this->campaignId, $this->confirmationBlock, $noMember, $share_utm_source);
+          $action_technical_type = $param->action_technical_type;
+          $sendResult = $this->sendEmail($this->isAnonymous, $h->emails[0]->email, $contact['id'], $activity['id'], $this->campaignId, $this->confirmationBlock, $noMember, $share_utm_source, $action_technical_type);
         }
         else {
           // workaround for rejected status
@@ -903,14 +905,15 @@ class CRM_Speakcivi_Page_Speakcivi extends CRM_Core_Page {
    * @param $confirmationBlock
    * @param $noMember
    * @param string $share_utm_source
+   * @param string $action_technical_type
    *
    * @return array
    */
-  public function sendEmail($isAnonymous, $email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source = '') {
+  public function sendEmail($isAnonymous, $email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source = '', $action_technical_type = '') {
     if ($isAnonymous) {
       return array('values' => 1);
     } else {
-      return $this->sendConfirm($email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source);
+      return $this->sendConfirm($email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source, $action_technical_type);
     }
   }
 
@@ -924,11 +927,12 @@ class CRM_Speakcivi_Page_Speakcivi extends CRM_Core_Page {
    * @param $confirmationBlock
    * @param $noMember
    * @param $share_utm_source
+   * @param $action_technical_type
    *
    * @return array
    * @throws CiviCRM_API3_Exception
    */
-  public function sendConfirm($email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source = '') {
+  public function sendConfirm($email, $contactId, $activityId, $campaignId, $confirmationBlock, $noMember, $share_utm_source = '', $action_technical_type = '') {
     $params = array(
       'sequential' => 1,
       'toEmail' => $email,
@@ -937,6 +941,7 @@ class CRM_Speakcivi_Page_Speakcivi extends CRM_Core_Page {
       'campaign_id' => $campaignId,
       'confirmation_block' => $confirmationBlock,
       'no_member' => $noMember,
+      'action_technical_type' => $action_technical_type,
     );
     if ($share_utm_source) {
       $params['share_utm_source'] = $share_utm_source;

--- a/amqp/consumer.php
+++ b/amqp/consumer.php
@@ -90,7 +90,7 @@ function handleError($msg, $error, $retry=false) {
   }
   
   //In some cases (e.g. a lost connection), dying and respawning can solve the problem
-  debugAmqp("Dying and hopefully respawning from ashes...");
+  debugAmqp("Dying and hopefully respawning from ashes..." . $error);
   die(1);
 }
 
@@ -111,6 +111,7 @@ function isConnectionLostError($sessionStatus) {
 $callback = function($msg) {
   global $msg_since_check;
   try {
+
     $json_msg = json_decode($msg->body);
     if ($json_msg) {
       $msg_handler = new CRM_Speakcivi_Page_Speakcivi();

--- a/api/v3/Speakcivi.php
+++ b/api/v3/Speakcivi.php
@@ -34,16 +34,21 @@ function civicrm_api3_speakcivi_sendconfirm($params) {
 
   $campaignObj = new CRM_Speakcivi_Logic_Campaign($campaignId);
   $locale = $campaignObj->getLanguage();
+
+  $speakout_campaign = CRM_Speakcivi_Logic_Cache_SpeakoutCampaign::getCampaign(
+    $campaignObj->determineSpeakoutDomain($action_technical_type),
+    $campaignObj->campaign['external_identifier']
+  );
+
   $params['from'] = $campaignObj->getSenderMail();
   $params['format'] = NULL;
 
   if ($confirmationBlock) {
     $params['subject'] = $campaignObj->getSubjectNew();
-    $message = $campaignObj->getMessageNew();
-  }
-  else {
-    $params['subject'] = $campaignObj->getSubjectCurrent();
-    $message = $campaignObj->getMessageCurrent();
+    $message = $speakout_campaign->getMessageNew();
+  } else {
+    $params['subject'] = $speakout_campaign['thankyou_subject'];
+    $message = $speakout_campaign['thankyou_body'];
   }
 
   if (!$message) {

--- a/api/v3/Speakcivi.php
+++ b/api/v3/Speakcivi.php
@@ -70,9 +70,9 @@ function civicrm_api3_speakcivi_sendconfirm($params) {
   }
 
   # TODO: Cache the speakout campaign details...
-  $speakout_campaign = (array) $campaignObj->getRemoteCampaign(
-      $campaignObj->determineSpeakoutDomain($action_technical_type),
-      $campaignObj->campaign['external_identifier']
+  $speakout_campaign = CRM_Speakcivi_Logic_Cache_SpeakoutCampaign::getCampaign(
+    $campaignObj->determineSpeakoutDomain($action_technical_type),
+    $campaignObj->campaign['external_identifier']
   );
 
   /* CONFIRMATION_BLOCK */


### PR DESCRIPTION
Read the Speakout campaign details directly from Speakout, skipping the CiviCRM tables. Before using in production, this will need to cache the returned values somewhere.