### PR TITLE
Choose footer for reminders based on language in their names

### DIFF
--- a/CRM/Speakcivi/Logic/Language.php
+++ b/CRM/Speakcivi/Logic/Language.php
@@ -32,4 +32,44 @@ class CRM_Speakcivi_Logic_Language {
     return in_array($language, ['en_GB', 'en_US', 'en_UK']);
   }
 
+  /**
+   * Choose footer for reminder based on Language.
+   * Language in short format like EN, DE, IT...
+   * English version by default.
+   *
+   * @param string $shortLanguage
+   *
+   * @return int
+   */
+  public static function chooseFooter(string $shortLanguage = 'EN'): int {
+    $footers = self::footers();
+
+    return CRM_Utils_Array::value($shortLanguage, $footers);
+  }
+
+  /**
+   * Grab footers used for reminders and iterate it by language.
+   * Name of footer should ending by /REMINDER:[A-Z]{2}$/
+   * @return array
+   */
+  private static function footers(): array {
+    $key = __METHOD__;
+    $cache = Civi::cache('long')->get($key);
+    if (!isset($cache)) {
+      $query = "SELECT id, substr(name, -2) language
+                FROM civicrm_mailing_component
+                WHERE component_type = 'Footer' AND name LIKE '%REMINDER:__'
+                ORDER BY id";
+      $dao = CRM_Core_DAO::executeQuery($query);
+      $ids = [];
+      while ($dao->fetch()) {
+        $ids[$dao->language] = (int) $dao->id;
+      }
+      Civi::cache('long')->set($key, $ids);
+      return $ids;
+    }
+    return $cache;
+
+  }
+
 }

--- a/CRM/Speakcivi/Logic/Language.php
+++ b/CRM/Speakcivi/Logic/Language.php
@@ -49,7 +49,7 @@ class CRM_Speakcivi_Logic_Language {
 
   /**
    * Grab footers used for reminders and iterate it by language.
-   * Name of footer should ending by /REMINDER:[A-Z]{2}$/
+   * Name of footer should be /Footer [A-Z]{2}$/
    * @return array
    */
   private static function footers(): array {
@@ -58,7 +58,7 @@ class CRM_Speakcivi_Logic_Language {
     if (!isset($cache)) {
       $query = "SELECT id, substr(name, -2) language
                 FROM civicrm_mailing_component
-                WHERE component_type = 'Footer' AND name LIKE '%REMINDER:__'
+                WHERE component_type = 'Footer' AND name LIKE 'Footer __'
                 ORDER BY id";
       $dao = CRM_Core_DAO::executeQuery($query);
       $ids = [];

--- a/api/v3/Speakcivi.php
+++ b/api/v3/Speakcivi.php
@@ -516,7 +516,7 @@ function civicrm_api3_speakcivi_remind($params) {
           'dedupe_email' => 1,
           'from_name' => $email[$cid]['from_name'],
           'from_email' => $email[$cid]['from_email'],
-          'footer_id' => chooseFooter($language[$cid]),
+          'footer_id' => CRM_Speakcivi_Logic_Language::chooseFooter($language[$cid]),
         );
         $mailing = new CRM_Mailing_BAO_Mailing();
         $mm = $mailing->add($params);
@@ -1142,29 +1142,4 @@ function submitReminder($mailingId) {
     'scheduled_id' => 1,
   ];
   civicrm_api3('Mailing', 'submit', $submitParams);
-}
-
-function chooseFooter($language) {
-  switch ($language) {
-    case 'ES':
-      return 13;
-
-    case 'DE':
-      return 10;
-
-    case 'FR':
-      return 12;
-
-    case 'IT':
-      return 11;
-
-    case 'PL':
-      return 15;
-
-    case 'RO':
-      return 31;
-
-    default:
-      return 14;
-  }
 }


### PR DESCRIPTION
Assumptions:

* language in short format like EN, DE, IT...
* name of footer ending by `/REMINDER:[A-Z]{2}$/`, defined at page civicrm/admin/component?reset=1&action=browse
* when more than 1 footers configured for one language then the latest footer (bigger id) returns